### PR TITLE
📝 Fix `pronoun.is` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In terms of code, I have a [RoutineHub profile](https://routinehub.co/user/andyp
 
 ### Fun facts 🎱
 
-- 👤 Preferred pronouns: [he/they/them](https://pronoun.is/they)
+- 👤 Preferred pronouns: [he/they/them](https://wikipedia.org/wiki/Singular_they)
 - 🌱 I’m spending time learning 🐍 [MicroPython](https://micropython.org), and 🌐 Fediverse APIs like [ActivityPub](https://activitypub.rocks)... when I have time!
 - 📝 Favorite (most-used) editors: VS Code (GUI), vim (CLI)
 - 💻 First computer: [Acorn Electron](https://en.wikipedia.org/wiki/Acorn_Electron)


### PR DESCRIPTION
[pronoun.is](https://pronoun.is) seems to have been taken down, I've changed it to the Wikipedia page on the pronoun '_they_'. You could also use the Wikidata object [`Q3437264`](https://www.wikidata.org/wiki/Q3437264) for the link.